### PR TITLE
Feat/orders

### DIFF
--- a/src/main/java/com/example/delivery_app/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/delivery_app/domain/order/controller/OrderController.java
@@ -1,0 +1,130 @@
+package com.example.delivery_app.domain.order.controller;
+
+import static com.example.delivery_app.domain.order.dto.response.SuccessResponseDto.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.delivery_app.domain.order.dto.request.OrderRequestDto;
+import com.example.delivery_app.domain.order.dto.response.OrderResponseDto;
+import com.example.delivery_app.domain.order.dto.response.ResponseCode;
+import com.example.delivery_app.domain.order.dto.response.SuccessResponseDto;
+import com.example.delivery_app.domain.order.entity.OrderStatus;
+import com.example.delivery_app.domain.order.service.OrderService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/ordesr")
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+	private final OrderService orderService;
+
+	// FIXME: JWT 토큰에 저장된 유저 id 가져와야 함
+
+	/**
+	 * [Controller] 주문내역 리스트를 조회하는 메서드
+	 * @param request HTTP 요청 객체
+	 * @return 주문 내역 응답 리스트를 반환
+	 */
+	@GetMapping
+	public ResponseEntity<SuccessResponseDto<List<OrderResponseDto>>> getAllOrders(
+		HttpServletRequest request
+	) {
+		return createResponseEntityDto(
+			ResponseCode.ORDER_GET_LIST_SUCCESS,
+			request.getRequestURI(),
+			orderService.findAllOrders()
+		);
+	}
+
+	/**
+	 * [Controller] 주문내역 단일 조회하는 메서드
+	 * @param orderId 주문 id
+	 * @param request HTTP 요청 객체
+	 * @return 주문 내역 응답 DTO 반환
+	 */
+	@GetMapping("/{orderId}")
+	public ResponseEntity<SuccessResponseDto<OrderResponseDto>> getOrder(
+		@PathVariable(name = "orderId") Long orderId,
+		HttpServletRequest request) {
+		return createResponseEntityDto(
+			ResponseCode.ORDER_GET_DETAIL_SUCCESS,
+			request.getRequestURI(),
+			orderService.findById(orderId)
+		);
+	}
+
+	/**
+	 * FIXME: [Controller] 주문 요청(생성)하는 메서드
+	 * @param dto 주문 요청 DTO
+	 * @param request HTTP 요청 객체
+	 */
+	@PostMapping
+	public void sendOrder(
+		@Validated @RequestBody OrderRequestDto dto,
+		HttpServletRequest request) {
+		orderService.sendOrder(dto);
+	}
+
+	/**
+	 * [Controller/관리자] 주문 수락하는 메서드
+	 * @param orderId 주문 id
+	 * @param request HTTP 요청 객체
+	 * @return 수락한 주문 응답 객체를 반환
+	 */
+	@PatchMapping("/{orderId}/accept")
+	public ResponseEntity<SuccessResponseDto<OrderResponseDto>> acceptOrder(
+		@PathVariable(name = "orderId") Long orderId,
+		HttpServletRequest request) {
+		return createResponseEntityDto(
+			ResponseCode.ORDER_PATCH_ACCEPTED_SUCCESS,
+			request.getRequestURI(),
+			orderService.requestOrder(orderId, OrderStatus.ACCEPTED)
+		);
+	}
+
+	/**
+	 * [Controller/관리자] 주문 완료하는 메서드
+	 * @param orderId 주문 id
+	 * @param request HTTP 요청 객체
+	 * @return 배달완료한 주문 응답 객체를 반환
+	 */
+	@PatchMapping("/{orderId}/complete")
+	public ResponseEntity<SuccessResponseDto<OrderResponseDto>> completeOrder(
+		@PathVariable(name = "orderId") Long orderId,
+		HttpServletRequest request) {
+		return createResponseEntityDto(
+			ResponseCode.ORDER_PATCH_COMPLETED_SUCCESS,
+			request.getRequestURI(),
+			orderService.requestOrder(orderId, OrderStatus.DELIVERED)
+		);
+	}
+
+	/**
+	 * [Controller/관리자] 주문을 거절하는 메서드
+	 * @param storeId 주문 id
+	 * @param request HTTP 요청 객체
+	 * @return 배달거절한 주문 응답 객체를 반환
+	 */
+	@PatchMapping("/{storeId}/reject")
+	public ResponseEntity<SuccessResponseDto<OrderResponseDto>> rejectOrder(
+		@PathVariable(name = "storeId") Long storeId,
+		HttpServletRequest request) {
+		return createResponseEntityDto(
+			ResponseCode.ORDER_PATCH_REJECTED_SUCCESS,
+			request.getRequestURI(),
+			orderService.requestOrder(storeId, OrderStatus.CANCELLED)
+		);
+	}
+}

--- a/src/main/java/com/example/delivery_app/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/delivery_app/domain/order/controller/OrderController.java
@@ -24,7 +24,7 @@ import com.example.delivery_app.domain.order.service.OrderService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
-@RequestMapping("/api/ordesr")
+@RequestMapping("/api/orders")
 @RestController
 @RequiredArgsConstructor
 public class OrderController {

--- a/src/main/java/com/example/delivery_app/domain/order/dto/request/OrderRequestDto.java
+++ b/src/main/java/com/example/delivery_app/domain/order/dto/request/OrderRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.delivery_app.domain.order.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class OrderRequestDto {
+	private final Long storeId;
+	private final Long menuId;
+}

--- a/src/main/java/com/example/delivery_app/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/example/delivery_app/domain/order/dto/response/OrderResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.delivery_app.domain.order.dto.response;
+
+import com.example.delivery_app.domain.menu.entity.Menu;
+import com.example.delivery_app.domain.order.entity.OrderStatus;
+import com.example.delivery_app.domain.store.entity.Store;
+import com.example.delivery_app.domain.user.entity.User;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderResponseDto {
+	private final User user;
+	private final Store store;
+	private final Menu menu;
+	private final OrderStatus status;
+	private final int totalPrice;
+
+	@Builder
+	public OrderResponseDto(User user, Store store, Menu menu, OrderStatus status) {
+		this.user = user;
+		this.store = store;
+		this.menu = menu;
+		this.status = status;
+		this.totalPrice = menu.getPrice();
+	}
+}

--- a/src/main/java/com/example/delivery_app/domain/order/dto/response/ResponseCode.java
+++ b/src/main/java/com/example/delivery_app/domain/order/dto/response/ResponseCode.java
@@ -1,0 +1,20 @@
+package com.example.delivery_app.domain.order.dto.response;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ResponseCode {
+	ORDER_GET_LIST_SUCCESS(HttpStatus.OK, "주문 내역 리스트를 성공적으로 조회하였습니다."),
+	ORDER_GET_DETAIL_SUCCESS(HttpStatus.OK, "주문 상세 정보를 성공적으로 조회하였습니다."),
+	ORDER_POST_CREATE_SUCCESS(HttpStatus.CREATED, "주문이 성공적으로 요청되었습니다."),
+	ORDER_PATCH_ACCEPTED_SUCCESS(HttpStatus.OK, "주문이 수락되었습니다."),
+	ORDER_PATCH_COMPLETED_SUCCESS(HttpStatus.OK, "배달이 완료되었습니다."),
+	ORDER_PATCH_REJECTED_SUCCESS(HttpStatus.OK, "주문이 거절되었습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/example/delivery_app/domain/order/dto/response/SuccessResponseDto.java
+++ b/src/main/java/com/example/delivery_app/domain/order/dto/response/SuccessResponseDto.java
@@ -1,0 +1,45 @@
+package com.example.delivery_app.domain.order.dto.response;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SuccessResponseDto<T> {
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+	private final LocalDateTime timestamp;
+
+	private final int code;
+	private final String path;
+	private final String message;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL) // ✅ null 이면 응답 JSON 에서 생략됨
+	private final T data;
+
+	/**
+	 * 공통 응답 객체(SuccessResponseDto)를 ResponseEntity 객체로 감싸서 반환하는 메서드
+	 * Controller 에서 응답 객체를 공통화하기 위해서 사용됩니다.
+	 * @param responseCode 성공 응답 enum
+	 * @param path 요청 URI (ex: /api/orders)
+	 * @param data 응답할 제네릭 데이터
+	 * @return ResponseEntity 를 반환
+	 */
+	public static <T> ResponseEntity<SuccessResponseDto<T>> createResponseEntityDto(
+		ResponseCode responseCode,
+		String path,
+		T data
+	) {
+		SuccessResponseDto<T> dto = new SuccessResponseDto<>(
+			LocalDateTime.now(),
+			responseCode.getStatus().value(),
+			path,
+			responseCode.getMessage(),
+			data);
+		return ResponseEntity.status(responseCode.getStatus()).body(dto);
+	}
+}

--- a/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
+++ b/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
@@ -20,7 +20,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
+@Entity(name = "orders")
 @NoArgsConstructor
 @Getter
 public class Order extends BaseEntity {

--- a/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
+++ b/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
@@ -30,15 +30,15 @@ public class Order extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id")
+	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "store_id")
+	@JoinColumn(name = "store_id", nullable = false)
 	private Store store;
 
 	@OneToOne
-	@JoinColumn(name = "menu_id")
+	@JoinColumn(name = "menu_id", nullable = false)
 	private Menu menu;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
+++ b/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
@@ -16,11 +16,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity(name = "orders")
+@Table(name = "orders")
 @NoArgsConstructor
 @Getter
 public class Order extends BaseEntity {

--- a/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
+++ b/src/main/java/com/example/delivery_app/domain/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.example.delivery_app.domain.order.entity;
 
+import com.example.delivery_app.common.entity.BaseEntity;
 import com.example.delivery_app.domain.menu.entity.Menu;
 import com.example.delivery_app.domain.store.entity.Store;
 import com.example.delivery_app.domain.user.entity.User;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @Getter
-public class Order {
+public class Order extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,6 +58,10 @@ public class Order {
 		this.status = status;
 	}
 
+	/**
+	 *🚀 주문정보의 상태를 변경하는 메서드
+	 * @param status 주문 상태 enum
+	 */
 	public void setOrderStatus(OrderStatus status) {
 		this.status = status;
 	}

--- a/src/main/java/com/example/delivery_app/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/delivery_app/domain/order/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.example.delivery_app.domain.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.delivery_app.domain.order.entity.Order;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/com/example/delivery_app/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/delivery_app/domain/order/service/OrderService.java
@@ -1,0 +1,82 @@
+package com.example.delivery_app.domain.order.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.delivery_app.domain.order.dto.request.OrderRequestDto;
+import com.example.delivery_app.domain.order.dto.response.OrderResponseDto;
+import com.example.delivery_app.domain.order.entity.Order;
+import com.example.delivery_app.domain.order.entity.OrderStatus;
+import com.example.delivery_app.domain.order.repository.OrderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+	private final OrderRepository orderRepository;
+
+	/**
+	 * [Service] 주문내역 리스트 조회 메서드
+	 * @return 주문 응답 DTO 리스트로 반환
+	 */
+	@Transactional(readOnly = true)
+	public List<OrderResponseDto> findAllOrders() {
+		return orderRepository.findAll().stream().map(
+			order -> OrderResponseDto.builder()
+				.user(order.getUser())
+				.store(order.getStore())
+				.menu(order.getMenu())
+				.status(order.getStatus())
+				.build()
+		).toList();
+	}
+
+	/**
+	 * [Service] 주문내역 단건 조회 메서드
+	 * @param orderId 주문 id
+	 * @return 주문 응답 DTO 반환
+	 */
+	@Transactional(readOnly = true)
+	public OrderResponseDto findById(Long orderId) {
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new RuntimeException("주문내역이 없습니다."));
+		return OrderResponseDto.builder()
+			.user(order.getUser())
+			.menu(order.getMenu())
+			.store(order.getStore())
+			.status(order.getStatus())
+			.build();
+	}
+
+	/**
+	 * [Service] 주문 생성(요청) 메서드
+	 * @param requestDto 주문 요청 DTO
+	 */
+	@Transactional
+	public void sendOrder(OrderRequestDto requestDto) {
+		// FIXME: Store, Menu, User 정보로 Order 객체 생성해야 함
+	}
+
+	/**
+	 * [Service] 주문 상태 변경 메서드
+	 * @param orderId 주문 id
+	 * @param status 주문 상태
+	 * @return 주문 응답 DTO 반환
+	 */
+	@Transactional
+	public OrderResponseDto requestOrder(Long orderId, OrderStatus status) {
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new RuntimeException("주문내역이 없습니다."));
+		order.setOrderStatus(status);
+
+		return OrderResponseDto.builder()
+			.user(order.getUser())
+			.menu(order.getMenu())
+			.store(order.getStore())
+			.status(order.getStatus())
+			.build();
+	}
+}


### PR DESCRIPTION
- Order 엔티티 클래스`orders`로 테이블명 수정하였습니다.
`order`가 예약어라 경고가 뜨네요..!

- Order 엔티티 클래스에 `@Column` 어노테이션을 삭제했었는데,
`@JoinColumn` 어노테이션이 해당 역할을 같이 해주고 있었습니다.
해당 어노테이션에 `nullable` 설정하였습니다!

- Controller, Service, Repository 생성하여 간단 CRUD 구현하였습니다.
`Delete` 메소드 사용할 부분은 없는 것 같습니다..! 확인부탁드립니다!

- `Order` 도메인 공통 응답 DTO (`SuccessResponseDto`) 적용하였습니다.
또한, 관련 `ResponseCode` Enum클래스로 응답정보들을 추상화하였습니다.

- `SuccessResponseDto`에서 생성자를 통해 바로 `ResponseEntity`로 감싸고 반환하게 하여
`Controller`에서 쉽게 사용할 수 있게 해봤습니다.

