### PR TITLE
fix : 가게 단건 조회시 메뉴가 안끌려나오는 문제 해결

### DIFF
--- a/src/main/java/com/example/delivery_app/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/delivery_app/domain/store/controller/StoreController.java
@@ -52,7 +52,7 @@ public class StoreController {
 
 	@GetMapping("/{storeId}")
 	public ResponseEntity<CommonResponseDto<StoreResponseDto>> getStoreById(@PathVariable Long storeId) {
-		StoreResponseDto store = storeService.getPostById(storeId);
+		StoreResponseDto store = storeService.getStoreById(storeId);
 		return ResponseEntity.ok(CommonResponseDto.of(StoreSuccessCode.STORE_GET_BY_ID_SUCCESS, store));
 	}
 

--- a/src/main/java/com/example/delivery_app/domain/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/com/example/delivery_app/domain/store/dto/response/StoreResponseDto.java
@@ -56,7 +56,7 @@ public class StoreResponseDto {
 			.openTime(store.getOpenTime().toString())
 			.closeTime(store.getCloseTime().toString())
 			.menus(store.getMenus().stream()
-				.filter(menu -> menu.isDeleted())
+				.filter(menu -> !menu.isDeleted())
 				.map(MenuResponseDto::fromMenu)
 				.collect(Collectors.toList()))
 			.build();

--- a/src/main/java/com/example/delivery_app/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/delivery_app/domain/store/repository/StoreRepository.java
@@ -20,7 +20,9 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 	@Query("SELECT s FROM Store s WHERE s.status = :status")
 	Page<Store> findAllByStatus(@Param("status") StoreStatus status, Pageable pageable);
 
-	@Query("SELECT s FROM Store s LEFT JOIN FETCH s.menus WHERE s.status = :status AND s.storeId = :storeId")
+	@Query("SELECT s FROM Store s "
+		+ "LEFT JOIN FETCH s.menus m "
+		+ "WHERE s.status = :status AND s.storeId = :storeId")
 	Optional<Store> findByIdAndStatusWithMenus(@Param("storeId") Long storeId, @Param("status") StoreStatus status);
 
 	@Query("SELECT COUNT(s) FROM Store s WHERE s.user.id = :userId AND s.status = 'ACTIVE'")

--- a/src/main/java/com/example/delivery_app/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/delivery_app/domain/store/service/StoreService.java
@@ -14,7 +14,7 @@ public interface StoreService {
 
 	StoreResponseDto saveStore(StoreRequestDto storeRequestDto, UserAuth userAuth);
 
-	StoreResponseDto getPostById(Long storeId);
+	StoreResponseDto getStoreById(Long storeId);
 
 	Page<StoreGetAllResponseDto> getAllStoreList(Pageable pageable);
 

--- a/src/main/java/com/example/delivery_app/domain/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/example/delivery_app/domain/store/service/StoreServiceImpl.java
@@ -60,8 +60,9 @@ public class StoreServiceImpl implements StoreService {
 		return StoreResponseDto.fromStore(savedStore);
 	}
 
+	@Transactional
 	@Override
-	public StoreResponseDto getPostById(Long storeId) {
+	public StoreResponseDto getStoreById(Long storeId) {
 		Store store = storeRepository.findByIdAndStatusWithMenus(storeId, StoreStatus.ACTIVE)
 			.orElseThrow(() -> new CustomException(StoreErrorCode.STORE_NOT_FOUND));
 


### PR DESCRIPTION
검색과 지피티 활용해서 문제가 어디서 생기나 찾아봤더니 menuoptions가 추가되면서 세션에서 초기화 해야할 것이 menu와 menuoptions 두개가 되버리는 바람에 menu 초기화 되고 세션이 닫혀서 menuoptions가 로딩되지 못하는 문제였습니다 서비스단 메서드에 트랜잭셔널을 달아서 트랜잭션 내에서 세션을 열고 초기화 하게 만들어서 문제가 해결 되었습니다!